### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ githubCallbackURL=http://localhost:3000/auth/github/callback
 Now just open up a terminal to the app's directory and run the following commands: 
 `npm install` to install the project dependencies.  
 `mongod` to start MongoDB.
+
+Finally, from a separate terminal session:
 `node server` to run LetsMeet on port `3000`.


### PR DESCRIPTION
Clearly stated that `node server` should be ran from another terminal session.